### PR TITLE
Fix docker workflow for forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/holoarchivists/hoshinova
+          ghcr.io/${{ github.repository }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr


### PR DESCRIPTION
Replace hardcoed repository name with name from Github context - Allow building images in forks without hardcoding the repository name