### PR TITLE
Add config option to restrict access to the config file through the API

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -34,6 +34,8 @@ notify_on = ["waiting", "recording", "done", "failed"]
 bind_address = "0.0.0.0:1104"
 # Path to a unix socket to listen on instead of / in addition to a TCP port.
 # unix_path = "/tmp/hoshinova.sock"
+# Restrict access to the config API (read and write the config file), but allow reloading
+restrict_config_api = true
 
 [[channel]]
 id = "UCP0BspO_AMEe3aQqqpo89Dg"

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,8 @@ pub struct SlackConfig {
 pub struct WebserverConfig {
     pub bind_address: Option<String>,
     pub unix_path: Option<String>,
+    #[serde(default)]
+    pub restrict_config_api: bool,
 }
 
 impl Default for WebserverConfig {
@@ -136,6 +138,7 @@ impl Default for WebserverConfig {
         WebserverConfig {
             bind_address: None,
             unix_path: None,
+            restrict_config_api: false,
         }
     }
 }
@@ -249,6 +252,7 @@ mod tests {
         let ws = WebserverConfig::default();
         assert!(ws.bind_address.is_none());
         assert!(ws.unix_path.is_none());
+        assert!(!ws.restrict_config_api);
     }
 
     #[test]


### PR DESCRIPTION
Intended use - being able to have secrets (e.g. notifier webhooks) and sharing Hoshinova to other people