### PR TITLE
Add webhook_url_file option for Discord and Slack notifiers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -113,14 +113,16 @@ pub struct NotifierConfig {
 #[derive(Clone, TS, Serialize, Deserialize, Debug, PartialEq)]
 #[ts(export)]
 pub struct DiscordConfig {
-    pub webhook_url: String,
+    pub webhook_url: Option<String>,
+    pub webhook_url_file: Option<String>,
     pub notify_on: Vec<TaskStatus>,
 }
 
 #[derive(Clone, TS, Serialize, Deserialize, Debug, PartialEq)]
 #[ts(export)]
 pub struct SlackConfig {
-    pub webhook_url: String,
+    pub webhook_url: Option<String>,
+    pub webhook_url_file: Option<String>,
     pub notify_on: Vec<TaskStatus>,
 }
 

--- a/src/module/notifier/slack_notifier.rs
+++ b/src/module/notifier/slack_notifier.rs
@@ -1,6 +1,6 @@
 use super::Notifier;
 use crate::{config::Config, module::{Notification, TaskStatus}, APP_USER_AGENT};
-use anyhow::Result;
+use anyhow::{Result, Context};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::Serialize;
@@ -36,11 +36,32 @@ impl Slack {
             .expect("Failed to create client");
         Self { config, client }
     }
+
+    async fn get_webhook_url(&self) -> Result<Option<String>> {
+        let cfg = self.config.read().await;
+        let slack_cfg = cfg.notifier.as_ref().and_then(|n| n.slack.as_ref());
+        if let Some(cfg) = slack_cfg {
+            if let Some(file_path) = &cfg.webhook_url_file {
+                let url = tokio::fs::read_to_string(file_path)
+                    .await
+                    .context("Failed to read webhook_url_file")?;
+                return Ok(Some(url.trim().to_string()));
+            }
+            return Ok(cfg.webhook_url.clone());
+        }
+        Ok(None)
+    }
 }
 
 #[async_trait]
 impl Notifier for Slack {
     async fn send_notification(&self, notification: &Notification) -> Result<()> {
+        let webhook_url = self.get_webhook_url().await?;
+        if webhook_url.is_none() {
+            return Ok(()); // Skip if no webhook URL is configured
+        }
+        let webhook_url = webhook_url.unwrap();
+
         let cfg = {
             let cfg = self.config.read().await;
             let not = cfg.notifier.clone();
@@ -76,7 +97,7 @@ impl Notifier for Slack {
 
         let res = self
             .client
-            .post(&cfg.webhook_url)
+            .post(&webhook_url)
             .header("Content-Type", "application/json")
             .json(&message)
             .send()


### PR DESCRIPTION
Store and read the webhook URL from a file to hide it from the config API